### PR TITLE
Add encrypted payload for direct links

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Or install it yourself as:
     $ gem install peanut_labs
 
 ## Usage
-You need to provide you app_id and and app_key. 
+You need to provide you app_id and and app_key.
 Perfect place to do that in rails app is config/initialize/peanutlabs.rb file
 
 ```
@@ -51,10 +51,30 @@ Whitelist was taken from official documentation:
 http://peanut-labs.github.io/publisher-doc/index.html#ipwhitelist
 
 ### Iframe
-TODO: Explain here how to build an iframe link
+
+```
+ruby
+PeanutLabs::Builder::IframeUrl.call(id: user.pid)
+```
+
+*Possible attributes*
+
+id: required, public user ID (highly recommended not to expose descending IDs in here)
+dob: not required, classes accepted - Date, DateTime, Time or formatted "MM-DD-YYYY" string
+sex: not required, 1 for male, 2 for female
 
 ### Direct Links
-TODO: Explain how to build direct links
+
+```
+ruby
+PeanutLabs::Builder::DirectLink.call(user.pid, attributes = {})
+```
+
+*Possible attributes (not required)*
+
+payload: a hash with user data attributes for encryption
+sub_id: a secure session id. Will be returned during postback notification
+zl: survey language (for some reason, PN translates only interface but not questions)
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -63,10 +63,9 @@ Be a good lad and write specs, we love code we can rely on.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/saberespoder/peanut_labs. 
+Bug reports and pull requests are welcome on GitHub at https://github.com/saberespoder/peanut_labs.
 
 
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/peanut_labs.rb
+++ b/lib/peanut_labs.rb
@@ -2,6 +2,7 @@ require "peanut_labs/version"
 require 'peanut_labs/credentials'
 require 'peanut_labs/errors'
 require 'peanut_labs/builder/user_id'
+require 'peanut_labs/builder/user_payload'
 require 'peanut_labs/builder/profile'
 require 'peanut_labs/builder/iframe_url'
 require 'peanut_labs/builder/direct_link'

--- a/lib/peanut_labs/builder/direct_link.rb
+++ b/lib/peanut_labs/builder/direct_link.rb
@@ -13,7 +13,7 @@ module PeanutLabs
       # user_pid – the user’s id within system
       # payload  – a hash with user data attributes for encryption
       # sub_id   – a secure session id. Will be returned during postback notification
-      # zl       – survey interface language (for some reason, PN only translates interface but not questions)
+      # zl       – survey language (for some reason, PN translates only interface but not questions)
 
       def self.call(user_pid, attrs = {})
         raise UserIdMissingError if user_pid.nil? || user_pid.empty?

--- a/lib/peanut_labs/builder/direct_link.rb
+++ b/lib/peanut_labs/builder/direct_link.rb
@@ -1,6 +1,7 @@
 require_relative '../credentials'
 require_relative '../errors'
 require_relative 'user_id'
+require 'uri'
 
 module PeanutLabs
   module Builder
@@ -9,18 +10,19 @@ module PeanutLabs
 
       # Parameters:
       # user_id - the user’s id within system
-      # sub_id - A secure session id. Will be returned during postback notification.
+      # sub_id  - A secure session id. Will be returned during postback notification.
 
-      def self.call(user_id, sub_id=nil)
+      def self.call(user_id, sub_id = nil)
         raise UserIdMissingError if user_id.nil? || user_id.empty?
 
-        result = "#{ENDPOINT}/?pub_id=#{Credentials.id}&user_id=#{Builder::UserId.new(user_id).call}"
+        attributes = {
+          pub_id:  Credentials.id,
+          user_id: Builder::UserId.new(user_id).call
+        }
 
-        if sub_id
-          result << "&sub_id=#{sub_id}"
-        end
+        attributes[:sub_id] = sub_id if sub_id
 
-        result
+        "#{ENDPOINT}/?#{URI.encode_www_form(attributes)}"
       end
     end
   end

--- a/lib/peanut_labs/builder/direct_link.rb
+++ b/lib/peanut_labs/builder/direct_link.rb
@@ -7,7 +7,7 @@ require 'uri'
 module PeanutLabs
   module Builder
     class DirectLink
-      ENDPOINT = "https://dlink.peanutlabs.com/direct_link".freeze
+      ENDPOINT = 'https://dlink.peanutlabs.com/direct_link'.freeze
 
       # Parameters:
       # user_pid – the user’s id within system
@@ -17,6 +17,7 @@ module PeanutLabs
 
       def self.call(user_pid, attrs = {})
         raise UserIdMissingError if user_pid.nil? || user_pid.empty?
+        raise PayloadObjectError if attrs[:payload] && attrs[:payload].class != Hash
 
         user_id              = Builder::UserId.new(user_pid).call
         params               = { pub_id: Credentials.id, user_id: user_id }

--- a/lib/peanut_labs/builder/direct_link.rb
+++ b/lib/peanut_labs/builder/direct_link.rb
@@ -13,14 +13,14 @@ module PeanutLabs
       # user_pid – the user’s id within system
       # payload  – a hash with user data attributes for encryption
       # sub_id   – a secure session id. Will be returned during postback notification
+      # zl       – survey interface language (for some reason, PN only translates interface but not questions)
 
       def self.call(user_pid, attrs = {})
-        # @TODO: Be able to pass user language as attribute
         raise UserIdMissingError if user_pid.nil? || user_pid.empty?
 
-        user_id          = Builder::UserId.new(user_pid).call
-        params           = { pub_id: Credentials.id, user_id: user_id }
-        payload, sub_id  = attrs[:payload], attrs[:sub_id]
+        user_id              = Builder::UserId.new(user_pid).call
+        params               = { pub_id: Credentials.id, user_id: user_id }
+        payload, sub_id, zl  = attrs[:payload], attrs[:sub_id], attrs[:zl]
 
         if payload && payload.any?
           encryped = Builder::UserPayload.call(payload.merge(user_id: user_id))
@@ -28,6 +28,7 @@ module PeanutLabs
         end
 
         params[:sub_id] = sub_id if sub_id
+        params[:zl]     = zl if zl
 
         "#{ENDPOINT}/?#{URI.encode_www_form(params)}"
       end

--- a/lib/peanut_labs/builder/iframe_url.rb
+++ b/lib/peanut_labs/builder/iframe_url.rb
@@ -16,7 +16,9 @@ module PeanutLabs
 #     params[:dob] -> not required, classes accepted - Date, DateTime, Time or formatted "MM-DD-YYYY" string
 #     params[:sex] -> not required, 1 for male, 2 for female
 #
+
       def self.call(params)
+        # @TODO: Be able to pass iframe language
         raise PeanutLabs::UserIdMissingError if params[:id].nil? || params[:id].empty?
 
         result = "#{ENDPOINT}?userId=#{UserId.new(params[:id]).call}"

--- a/lib/peanut_labs/builder/user_id.rb
+++ b/lib/peanut_labs/builder/user_id.rb
@@ -9,7 +9,7 @@ module PeanutLabs
       # highly recommended not to expose descending id's in here
 
       def initialize(public_user_id)
-        raise PeanutLabs::UserIdAlphanumericError if public_user_id.match(/\A\p{Alnum}+\z/).nil?
+        raise UserIdAlphanumericError if public_user_id.match(/\A\p{Alnum}+\z/).nil?
         @public_user_id = public_user_id
       end
 

--- a/lib/peanut_labs/builder/user_payload.rb
+++ b/lib/peanut_labs/builder/user_payload.rb
@@ -1,0 +1,23 @@
+require 'openssl'
+require 'base64'
+
+module PeanutLabs
+  module Builder
+    class UserPayload
+      IV_SIZE = 16.freeze
+
+      def self.call(payload={})
+        iv = get_init_vector
+        { iv: iv }
+      end
+
+      private
+
+      def self.get_init_vector
+        cipher    = OpenSSL::Cipher.new('AES-128-CBC')
+        random_iv = cipher.random_iv
+        CGI.escape(Base64.strict_encode64(random_iv))
+      end
+    end
+  end
+end

--- a/lib/peanut_labs/builder/user_payload.rb
+++ b/lib/peanut_labs/builder/user_payload.rb
@@ -11,8 +11,13 @@ module PeanutLabs
       ENCRYPTION      = 'AES-128-CBC'.freeze
       BLOCK_SIZE      = 16.freeze
 
-      # It turns out that we don't have add AES padding inside `encrypt_json_payload`
-      # because unlike PHP implementation OpenSSL applies them itself
+#
+#     This class is Ruby implementation of encoding algorithm
+#     described in http://peanut-labs.github.io/publisher-doc/#iv-payload
+#
+#     It turns out that we don't have add AES padding inside `encrypt_json_payload`
+#     because unlike PHP implementation OpenSSL applies them itself
+#
 
       def self.call(payload = {}, init_vector = nil)
         raise PayloadMandatoryError if (MANDATORY_ATTRS - payload.keys.map(&:to_sym)).any?

--- a/lib/peanut_labs/builder/user_payload.rb
+++ b/lib/peanut_labs/builder/user_payload.rb
@@ -14,6 +14,9 @@ module PeanutLabs
       # because unlike PHP implementation OpenSSL applies them itself
 
       def self.call(payload = {}, init_vector = nil)
+        # @TODO: Make sure that `payload` is a hash
+        # @TODO: Validate avaliability of mandatory attributes
+
         json_payload = payload.to_json
         init_vector  = get_init_vector unless init_vector
 

--- a/lib/peanut_labs/builder/user_payload.rb
+++ b/lib/peanut_labs/builder/user_payload.rb
@@ -1,3 +1,4 @@
+require_relative '../credentials'
 require 'openssl'
 require 'base64'
 require 'cgi'
@@ -17,10 +18,9 @@ module PeanutLabs
         init_vector  = get_init_vector unless init_vector
 
         return {
-          # @TODO: Fetch application key from credentials
           iv:      init_vector,
           payload: encrypt_json_payload(json_payload,
-            'abcdef0123456789abcdef0123456789',
+            Credentials.key,
             init_vector
           )
         }

--- a/lib/peanut_labs/builder/user_payload.rb
+++ b/lib/peanut_labs/builder/user_payload.rb
@@ -1,22 +1,48 @@
 require 'openssl'
 require 'base64'
+require 'json'
 
 module PeanutLabs
   module Builder
     class UserPayload
-      IV_SIZE = 16.freeze
+      ENCRYPTION = 'AES-128-CBC'.freeze
+      BLOCK_SIZE = 16.freeze
+
+      # It turns out that we don't have add AES padding inside `encrypt_json_payload`
+      # because unlike PHP implementation OpenSSL applies them itself
 
       def self.call(payload={})
-        iv = get_init_vector
-        { iv: iv }
+        json_payload = payload.to_json
+        init_vector  = get_init_vector
+
+        return {
+          iv:      init_vector,
+          payload: encrypt_json_payload(json_payload, 'abcdef0123456789abcdef0123456789', 'LB4Fs5awRnFYoLm%2BMTcANg%3D%3D')
+        }
       end
 
       private
 
       def self.get_init_vector
-        cipher    = OpenSSL::Cipher.new('AES-128-CBC')
-        random_iv = cipher.random_iv
-        CGI.escape(Base64.strict_encode64(random_iv))
+        cipher = OpenSSL::Cipher.new(ENCRYPTION).encrypt
+        CGI.escape(Base64.strict_encode64(cipher.random_iv))
+      end
+
+      def self.encrypt_json_payload(payload, application_key, iv)
+        # Convert application key into binary format
+        binary_key = [application_key].pack('H*')
+        # Encrypt payload
+        encrypted_payload = encrypt_payload(payload, binary_key, iv)
+
+        CGI.escape(Base64.strict_encode64(encrypted_payload))
+      end
+
+      def self.encrypt_payload(payload, application_key, iv)
+        cipher     = OpenSSL::Cipher.new(ENCRYPTION).encrypt
+        cipher.key = application_key
+        cipher.iv  = Base64.strict_decode64(CGI.unescape(iv))
+
+        cipher.update(payload) + cipher.final
       end
     end
   end

--- a/lib/peanut_labs/builder/user_payload.rb
+++ b/lib/peanut_labs/builder/user_payload.rb
@@ -15,7 +15,7 @@ module PeanutLabs
       # because unlike PHP implementation OpenSSL applies them itself
 
       def self.call(payload = {}, init_vector = nil)
-        raise PayloadMandatoryError if payload.keys.sort != MANDATORY_ATTRS.sort
+        raise PayloadMandatoryError if (MANDATORY_ATTRS - payload.keys.map(&:to_sym)).any?
 
         json_payload = payload.to_json
         init_vector  = get_init_vector unless init_vector

--- a/lib/peanut_labs/builder/user_payload.rb
+++ b/lib/peanut_labs/builder/user_payload.rb
@@ -11,13 +11,17 @@ module PeanutLabs
       # It turns out that we don't have add AES padding inside `encrypt_json_payload`
       # because unlike PHP implementation OpenSSL applies them itself
 
-      def self.call(payload={})
+      def self.call(payload = {}, init_vector = nil)
         json_payload = payload.to_json
-        init_vector  = get_init_vector
+        init_vector  = get_init_vector unless init_vector
 
         return {
+          # @TODO: Fetch application key from credentials
           iv:      init_vector,
-          payload: encrypt_json_payload(json_payload, 'abcdef0123456789abcdef0123456789', 'LB4Fs5awRnFYoLm%2BMTcANg%3D%3D')
+          payload: encrypt_json_payload(json_payload,
+            'abcdef0123456789abcdef0123456789',
+            init_vector
+          )
         }
       end
 
@@ -32,15 +36,15 @@ module PeanutLabs
         # Convert application key into binary format
         binary_key = [application_key].pack('H*')
         # Encrypt payload
-        encrypted_payload = encrypt_payload(payload, binary_key, iv)
+        encrypted_payload = encryptor(payload, binary_key, iv)
 
         CGI.escape(Base64.strict_encode64(encrypted_payload))
       end
 
-      def self.encrypt_payload(payload, application_key, iv)
+      def self.encryptor(payload, key, iv)
         cipher     = OpenSSL::Cipher.new(ENCRYPTION).encrypt
-        cipher.key = application_key
         cipher.iv  = Base64.strict_decode64(CGI.unescape(iv))
+        cipher.key = key
 
         cipher.update(payload) + cipher.final
       end

--- a/lib/peanut_labs/builder/user_payload.rb
+++ b/lib/peanut_labs/builder/user_payload.rb
@@ -1,5 +1,6 @@
 require 'openssl'
 require 'base64'
+require 'cgi'
 require 'json'
 
 module PeanutLabs

--- a/lib/peanut_labs/builder/user_payload.rb
+++ b/lib/peanut_labs/builder/user_payload.rb
@@ -7,15 +7,15 @@ require 'json'
 module PeanutLabs
   module Builder
     class UserPayload
-      ENCRYPTION = 'AES-128-CBC'.freeze
-      BLOCK_SIZE = 16.freeze
+      MANDATORY_ATTRS = %i(user_id cc dob sex).freeze
+      ENCRYPTION      = 'AES-128-CBC'.freeze
+      BLOCK_SIZE      = 16.freeze
 
       # It turns out that we don't have add AES padding inside `encrypt_json_payload`
       # because unlike PHP implementation OpenSSL applies them itself
 
       def self.call(payload = {}, init_vector = nil)
-        # @TODO: Make sure that `payload` is a hash
-        # @TODO: Validate avaliability of mandatory attributes
+        raise PayloadMandatoryError if payload.keys.sort != MANDATORY_ATTRS.sort
 
         json_payload = payload.to_json
         init_vector  = get_init_vector unless init_vector

--- a/lib/peanut_labs/errors.rb
+++ b/lib/peanut_labs/errors.rb
@@ -5,4 +5,6 @@ module PeanutLabs
   class DateOfBirthMissingError < StandardError; end
   class SexMissingError < StandardError; end
   class CountryMissingError < StandardError; end
+  class PayloadObjectError < StandardError; end
+  class PayloadMandatoryError < StandardError; end
 end

--- a/lib/peanut_labs/version.rb
+++ b/lib/peanut_labs/version.rb
@@ -1,3 +1,3 @@
 module PeanutLabs
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/spec/peanut_labs/builder/direct_link_spec.rb
+++ b/spec/peanut_labs/builder/direct_link_spec.rb
@@ -24,9 +24,15 @@ describe PeanutLabs::Builder::DirectLink do
     ).to eql 'https://dlink.peanutlabs.com/direct_link/?pub_id=0000&user_id=user1-0000-aa3ad22725&sub_id=random_sub_id'
   end
 
+  it 'should add zl to link' do
+    expect(
+      subject.call(user_id, zl: 'es')
+    ).to eql 'https://dlink.peanutlabs.com/direct_link/?pub_id=0000&user_id=user1-0000-aa3ad22725&zl=es'
+  end
+
   context 'with payload' do
-    it 'has expected attributes' do
-      payload = subject.call(user_id, payload: { sex: 1 }).split('?').last
+    it 'returns expected attributes' do
+      payload = subject.call(user_id, payload: { cc: 'US', sex: 1, dob: '1990-04-10', postal: '94104' }).split('?').last
       keys    = URI.decode_www_form(payload).map { |k, v| k }
 
       expect(keys).to include('pub_id', 'user_id', 'payload', 'iv')

--- a/spec/peanut_labs/builder/direct_link_spec.rb
+++ b/spec/peanut_labs/builder/direct_link_spec.rb
@@ -15,28 +15,39 @@ describe PeanutLabs::Builder::DirectLink do
   it 'should return a link' do
     expect(
       subject.call(user_id)
-    ).to eql "https://dlink.peanutlabs.com/direct_link/?pub_id=0000&user_id=user1-0000-aa3ad22725"
+    ).to eql 'https://dlink.peanutlabs.com/direct_link/?pub_id=0000&user_id=user1-0000-aa3ad22725'
   end
 
   it 'should add sub_id to link' do
     expect(
-      subject.call(user_id, 'random_sub_id')
-    ).to eql "https://dlink.peanutlabs.com/direct_link/?pub_id=0000&user_id=user1-0000-aa3ad22725&sub_id=random_sub_id"
+      subject.call(user_id, sub_id: 'random_sub_id')
+    ).to eql 'https://dlink.peanutlabs.com/direct_link/?pub_id=0000&user_id=user1-0000-aa3ad22725&sub_id=random_sub_id'
   end
 
-  context 'if user_id is missing throws error' do
-    it { expect { subject.call(nil) }.to raise_error(PeanutLabs::UserIdMissingError) }
-    it { expect { subject.call("") }.to raise_error(PeanutLabs::UserIdMissingError) }
+  context 'with payload' do
+    it 'has expected attributes' do
+      payload = subject.call(user_id, payload: { sex: 1 }).split('?').last
+      keys    = URI.decode_www_form(payload).map { |k, v| k }
+
+      expect(keys).to include('pub_id', 'user_id', 'payload', 'iv')
+    end
   end
 
-  context 'if user_id is not alphanumeric throws error' do
-    it { expect { subject.call('123~@~abc') }.to raise_error(PeanutLabs::UserIdAlphanumericError) }
-  end
+  context "errors" do
+    it 'if user_id is missing throws error' do
+      expect { subject.call(nil) }.to raise_error(PeanutLabs::UserIdMissingError)
+      expect { subject.call("") }.to raise_error(PeanutLabs::UserIdMissingError)
+    end
 
-  it 'should fail with missing Credential' do
-    PeanutLabs::Credentials.id = nil
-    PeanutLabs::Credentials.key = nil
+    it 'if user_id is not alphanumeric throws error' do
+      expect { subject.call('123~@~abc') }.to raise_error(PeanutLabs::UserIdAlphanumericError)
+    end
 
-    expect { subject.call(user_id) }.to raise_error PeanutLabs::CredentialsMissingError
+    it 'should fail with missing Credential' do
+      PeanutLabs::Credentials.id  = nil
+      PeanutLabs::Credentials.key = nil
+
+      expect { subject.call(user_id) }.to raise_error PeanutLabs::CredentialsMissingError
+    end
   end
 end

--- a/spec/peanut_labs/builder/direct_link_spec.rb
+++ b/spec/peanut_labs/builder/direct_link_spec.rb
@@ -32,24 +32,32 @@ describe PeanutLabs::Builder::DirectLink do
 
   context 'with payload' do
     it 'returns expected attributes' do
-      payload = subject.call(user_id, payload: { cc: 'US', sex: 1, dob: '1990-04-10', postal: '94104' }).split('?').last
+      payload = subject.call(user_id, payload: { cc: 'US', sex: 1, dob: '1990-04-10' }).split('?').last
       keys    = URI.decode_www_form(payload).map { |k, v| k }
 
       expect(keys).to include('pub_id', 'user_id', 'payload', 'iv')
     end
   end
 
-  context "errors" do
-    it 'if user_id is missing throws error' do
+  context 'throws error' do
+    it 'if user_id is missing' do
       expect { subject.call(nil) }.to raise_error(PeanutLabs::UserIdMissingError)
       expect { subject.call("") }.to raise_error(PeanutLabs::UserIdMissingError)
     end
 
-    it 'if user_id is not alphanumeric throws error' do
+    it 'if user_id is not alphanumeric' do
       expect { subject.call('123~@~abc') }.to raise_error(PeanutLabs::UserIdAlphanumericError)
     end
 
-    it 'should fail with missing Credential' do
+    it 'if payload is not a hash' do
+      expect { subject.call(user_id, payload: :symbol) }.to raise_error(PeanutLabs::PayloadObjectError)
+    end
+
+    it 'if mandatory attributes missed' do
+      expect { subject.call(user_id, payload: { sex: 1 }) }.to raise_error(PeanutLabs::PayloadMandatoryError)
+    end
+
+    it 'if Credential is missing' do
       PeanutLabs::Credentials.id  = nil
       PeanutLabs::Credentials.key = nil
 

--- a/spec/peanut_labs/builder/user_payload_spec.rb
+++ b/spec/peanut_labs/builder/user_payload_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe PeanutLabs::Builder::UserPayload do
+  let(:app_id)      { '0000' }
   let(:app_key)     { 'abcdef0123456789abcdef0123456789' }
   let(:init_vector) { nil } # Serves testing purposes and will not be passed in the real life
   let(:data) do
@@ -21,6 +22,10 @@ describe PeanutLabs::Builder::UserPayload do
         'ch-f' => ['10-1998', '11-1999']
       }
     }
+  end
+  before do
+    PeanutLabs::Credentials.id  = app_id
+    PeanutLabs::Credentials.key = app_key
   end
   subject { PeanutLabs::Builder::UserPayload.call(data, init_vector) }
 

--- a/spec/peanut_labs/builder/user_payload_spec.rb
+++ b/spec/peanut_labs/builder/user_payload_spec.rb
@@ -1,33 +1,64 @@
 require 'spec_helper'
 
 describe PeanutLabs::Builder::UserPayload do
-  let(:app_key) { 'abcdef0123456789abcdef0123456789' }
+  let(:app_key)     { 'abcdef0123456789abcdef0123456789' }
+  let(:init_vector) { nil } # Serves testing purposes and will not be passed in the real life
   let(:data) do
     {
-      user_id: 'user001-1001-2389d74882',
-      cc: 'US',
-      sex: 1,
-      dob: '1990-04-10',
-      postal: '94104',
-      profile_data: {
-        q122: ['qx122-0'],
-        q159: ['qx159-1'],
-        q102: ['qx102-105'],
-        q158: ['qx158-3'],
-        q101: ['qx101-2'],
-        q157: ['3'],
+      'user_id' => 'user001-1001-2389d74882',
+      'cc'      => 'US',
+      'sex'     => 1,
+      'dob'     => '1990-04-10',
+      'postal'  => '94104',
+      'profile_data' => {
+        'q122' => ['qx122-0'],
+        'q159' => ['qx159-1'],
+        'q102' => ['qx102-105'],
+        'q158' => ['qx158-3'],
+        'q101' => ['qx101-2'],
+        'q157' => ['3'],
         'ch-m' => ['4-2004'],
         'ch-f' => ['10-1998', '11-1999']
       }
     }
   end
-  subject { PeanutLabs::Builder::UserPayload.call(data) }
+  subject { PeanutLabs::Builder::UserPayload.call(data, init_vector) }
 
-  it 'iv attribute has expected length' do
-    expect(CGI.unescape(subject[:iv]).length).to eq 24
+  it 'has expected attributes' do
+    expect(subject.keys).to include(:iv, :payload)
   end
 
-  it 'returns encrypted payload' do
-    expect(subject[:payload]).to eq 'aVJyjog7mQrtUMUDZONYOAlSqBRa1%2BoMIhZhH6Qahs8hvWSflN7s7Z98fR8QyeqfdQ8blnp5x3B3IbuwwNQBORTfXRJ0lKWytvXa%2BUK%2FUCYOFPSvasgGIKVtolrHy7n6vJujtbpC3IKJxnWRbOtKV5Q5xw9Vz6hgzvhf%2FwNV3m9N0qkMxFon%2FNEu933mbQOEjgwswjWHjFGQ5%2BugTzCT5PX47nDnV8vXR014KCZcjGw8DtkGog5A%2B%2B4SdBbEOP0M9g165ZQ5nsFtyjy8960bRGef7UNey4hmoFiFvqlws%2BAhs7YAT%2Fb7c97K6amSCZm9TocPG4tJAqZYgoHTCApFgIuGbvfnlt%2B0%2FPSehNluyl8%3D'
+  context 'init vector' do
+    it 'always unique' do
+      first_call  = subject
+      second_call = PeanutLabs::Builder::UserPayload.call(data)
+      expect(first_call[:iv]).not_to eq(second_call[:iv])
+    end
+    it 'has expected length' do
+      expect(CGI.unescape(subject[:iv]).length).to eq 24
+    end
+  end
+
+  context 'payload' do
+    context 'with defined vector' do
+      let(:init_vector) { 'LB4Fs5awRnFYoLm%2BMTcANg%3D%3D' }
+      it 'returns expected value' do
+        expect(subject[:payload]).to eq 'aVJyjog7mQrtUMUDZONYOAlSqBRa1%2BoMIhZhH6Qahs8hvWSflN7s7Z98fR8QyeqfdQ8blnp5x3B3IbuwwNQBORTfXRJ0lKWytvXa%2BUK%2FUCYOFPSvasgGIKVtolrHy7n6vJujtbpC3IKJxnWRbOtKV5Q5xw9Vz6hgzvhf%2FwNV3m9N0qkMxFon%2FNEu933mbQOEjgwswjWHjFGQ5%2BugTzCT5PX47nDnV8vXR014KCZcjGw8DtkGog5A%2B%2B4SdBbEOP0M9g165ZQ5nsFtyjy8960bRGef7UNey4hmoFiFvqlws%2BAhs7YAT%2Fb7c97K6amSCZm9TocPG4tJAqZYgoHTCApFgIuGbvfnlt%2B0%2FPSehNluyl8%3D'
+      end
+    end
+
+    context 'with random vector' do
+      let(:iv)      { Base64.strict_decode64(CGI.unescape(subject[:iv])) }
+      let(:payload) { Base64.strict_decode64(CGI.unescape(subject[:payload])) }
+
+      it 'can be decrypted' do
+        decipher          = OpenSSL::Cipher.new('AES-128-CBC').decrypt
+        decipher.iv       = iv
+        decipher.key      = [app_key].pack('H*')
+        decrypted_payload = decipher.update(payload) + decipher.final
+
+        expect(JSON.parse(decrypted_payload)).to eq data
+      end
+    end
   end
 end

--- a/spec/peanut_labs/builder/user_payload_spec.rb
+++ b/spec/peanut_labs/builder/user_payload_spec.rb
@@ -1,10 +1,33 @@
 require 'spec_helper'
 
 describe PeanutLabs::Builder::UserPayload do
-  subject { PeanutLabs::Builder::UserPayload }
-  let(:payload) { subject.call }
+  let(:app_key) { 'abcdef0123456789abcdef0123456789' }
+  let(:data) do
+    {
+      user_id: 'user001-1001-2389d74882',
+      cc: 'US',
+      sex: 1,
+      dob: '1990-04-10',
+      postal: '94104',
+      profile_data: {
+        q122: ['qx122-0'],
+        q159: ['qx159-1'],
+        q102: ['qx102-105'],
+        q158: ['qx158-3'],
+        q101: ['qx101-2'],
+        q157: ['3'],
+        'ch-m' => ['4-2004'],
+        'ch-f' => ['10-1998', '11-1999']
+      }
+    }
+  end
+  subject { PeanutLabs::Builder::UserPayload.call(data) }
 
-  it "returns proper iv attribute" do
-    expect(CGI.unescape(payload[:iv]).length).to eq 24
+  it 'iv attribute has expected length' do
+    expect(CGI.unescape(subject[:iv]).length).to eq 24
+  end
+
+  it 'returns encrypted payload' do
+    expect(subject[:payload]).to eq 'aVJyjog7mQrtUMUDZONYOAlSqBRa1%2BoMIhZhH6Qahs8hvWSflN7s7Z98fR8QyeqfdQ8blnp5x3B3IbuwwNQBORTfXRJ0lKWytvXa%2BUK%2FUCYOFPSvasgGIKVtolrHy7n6vJujtbpC3IKJxnWRbOtKV5Q5xw9Vz6hgzvhf%2FwNV3m9N0qkMxFon%2FNEu933mbQOEjgwswjWHjFGQ5%2BugTzCT5PX47nDnV8vXR014KCZcjGw8DtkGog5A%2B%2B4SdBbEOP0M9g165ZQ5nsFtyjy8960bRGef7UNey4hmoFiFvqlws%2BAhs7YAT%2Fb7c97K6amSCZm9TocPG4tJAqZYgoHTCApFgIuGbvfnlt%2B0%2FPSehNluyl8%3D'
   end
 end

--- a/spec/peanut_labs/builder/user_payload_spec.rb
+++ b/spec/peanut_labs/builder/user_payload_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe PeanutLabs::Builder::UserPayload do
+  subject { PeanutLabs::Builder::UserPayload }
+  let(:payload) { subject.call }
+
+  it "returns proper iv attribute" do
+    expect(CGI.unescape(payload[:iv]).length).to eq 24
+  end
+end


### PR DESCRIPTION
This PR adds a support of encrypted payload for direct links (see description and PHP implementation [here](http://peanut-labs.github.io/publisher-doc/#iv-payload))