### PR TITLE
Fix whitelist matcher reverse logic

### DIFF
--- a/lib/peanut_labs/version.rb
+++ b/lib/peanut_labs/version.rb
@@ -1,3 +1,3 @@
 module PeanutLabs
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/lib/peanut_labs/whitelist.rb
+++ b/lib/peanut_labs/whitelist.rb
@@ -1,11 +1,12 @@
 module PeanutLabs
   class Whitelist
     # This should be used in rails routes.rb file, like this:
+    # IPs list is equal to the list from http://peanut-labs.github.io/publisher-doc/#ipwhitelist
     #
     # post "callback/peanutlabs" => "callback#peanutlabs", constraints: PeanutLabs::Whitelist
     #
 
-    RN_IPS = ['75.101.154.153',
+    ALLOWED_IPS = ['75.101.154.153',
               '54.243.235.176',
               '54.243.210.15',
               '54.243.204.6',
@@ -87,7 +88,7 @@ module PeanutLabs
               '107.20.152.198'].freeze
 
     def self.matches?(request)
-      !RN_IPS.include?(request.remote_ip)
+      !ALLOWED_IPS.include?(request.remote_ip)
     end
 
   end

--- a/lib/peanut_labs/whitelist.rb
+++ b/lib/peanut_labs/whitelist.rb
@@ -88,7 +88,7 @@ module PeanutLabs
               '107.20.152.198'].freeze
 
     def self.matches?(request)
-      !ALLOWED_IPS.include?(request.remote_ip)
+      ALLOWED_IPS.include?(request.remote_ip)
     end
 
   end

--- a/spec/peanut_labs/whitelist_spec.rb
+++ b/spec/peanut_labs/whitelist_spec.rb
@@ -7,10 +7,10 @@ describe PeanutLabs::Whitelist do
   subject { PeanutLabs::Whitelist }
 
   it "doesn't block whitelisted ips" do
-    expect(subject.matches?(Request.new('107.22.162.83'))).to be_falsy
+    expect(subject.matches?(Request.new('107.22.162.83'))).to be_truthy
   end
 
   it "blocks non-whitelisted ips" do
-    expect(subject.matches?(Request.new('127.0.0.1'))).to be_truthy
+    expect(subject.matches?(Request.new('127.0.0.1'))).to be_falsy
   end
 end


### PR DESCRIPTION
A reverse logic of the Whitelist matcher seems a bit confusing. Considering the fact that this list was supposed to be applied as a Rails constraint before this change allowed hosts used to be blacklisted and vise versa:
```ruby
post "callback/peanutlabs" => "callback#peanutlabs", constraints: PeanutLabs::Whitelist
```
